### PR TITLE
Re-add navigation Heading sensor

### DIFF
--- a/custom_components/cardata/sensor.py
+++ b/custom_components/cardata/sensor.py
@@ -391,7 +391,6 @@ async def async_setup_entry(
         location_descriptors = [
             "vehicle.cabin.infotainment.navigation.currentLocation.latitude",
             "vehicle.cabin.infotainment.navigation.currentLocation.longitude",
-            "vehicle.cabin.infotainment.navigation.currentLocation.heading",
         ]
         if descriptor in location_descriptors:
             return


### PR DESCRIPTION
Reenables navigation heading sensor, since that is useful and not included in device_tracker.