### PR TITLE
Remove fixed battery icon and add device class

### DIFF
--- a/custom_components/cardata/sensor.py
+++ b/custom_components/cardata/sensor.py
@@ -189,7 +189,6 @@ class CardataSocEstimateSensor(CardataEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.BATTERY
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "%"
-    _attr_icon = "mdi:battery-clock"
 
     def __init__(self, coordinator: CardataCoordinator, vin: str) -> None:
         super().__init__(coordinator, vin, "soc_estimate")
@@ -243,9 +242,9 @@ class CardataSocEstimateSensor(CardataEntity, SensorEntity):
 
 class CardataTestingSocEstimateSensor(CardataEntity, SensorEntity):
     _attr_should_poll = False
+    _attr_device_class = SensorDeviceClass.BATTERY    
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "%"
-    _attr_icon = "mdi:battery-clock"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: CardataCoordinator, vin: str) -> None:


### PR DESCRIPTION
Added device class for one and removed fixed icons, so that the fill state is taken from device class and an according icon in in HA is shown.

https://github.com/JjyKsi/bmw-cardata-ha/issues/42

New Extrapolation Testing sensor
State Of Charge (Predicted on Integration side)

Any hint, were a device class for the other sensors can be added:

Battery Charge Level at end of trip
State of Charge (Last Known)
State of Charge (Predicted on BMW SIDE)


