### PR TITLE
Set entity category attribute to device tracker

### DIFF
--- a/custom_components/cardata/device_tracker.py
+++ b/custom_components/cardata/device_tracker.py
@@ -81,6 +81,7 @@ class CardataDeviceTracker(CardataEntity, TrackerEntity):
     _attr_force_update = False
     _attr_translation_key = "car"
     _attr_name = None
+    _attr_entity_category = None
 
     def __init__(self, coordinator: CardataCoordinator, vin: str) -> None:
         """Initialize the tracker."""


### PR DESCRIPTION
By setting the category to None we prevent this device tracker to be assigned to the "Diagnostic" category

## Before
<img width="722" height="770" alt="before" src="https://github.com/user-attachments/assets/7443e02d-f8d8-4fc7-bb9e-cc8b45692ee8" />

## After
<img width="633" height="919" alt="after" src="https://github.com/user-attachments/assets/b9351357-41b0-49f9-ba3d-536eca3d5ff7" />
